### PR TITLE
Add GitHub Pages website

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,715 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>ArduRoomba - Breathe New Life Into Your Roomba</title>
+    <meta name="description" content="The definitive Arduino library for controlling legacy iRobot Roomba robots with WiFi and Bluetooth.">
+    <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🤖</text></svg>">
+    <style>
+        :root {
+            --primary: #2563eb;
+            --primary-dark: #1d4ed8;
+            --secondary: #10b981;
+            --bg: #ffffff;
+            --bg-alt: #f8fafc;
+            --text: #1e293b;
+            --text-muted: #64748b;
+            --border: #e2e8f0;
+            --code-bg: #1e293b;
+            --code-text: #e2e8f0;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, sans-serif;
+            line-height: 1.6;
+            color: var(--text);
+            background: var(--bg);
+        }
+
+        a {
+            color: var(--primary);
+            text-decoration: none;
+        }
+
+        a:hover {
+            text-decoration: underline;
+        }
+
+        .container {
+            max-width: 1100px;
+            margin: 0 auto;
+            padding: 0 1.5rem;
+        }
+
+        /* Header */
+        header {
+            background: var(--bg);
+            border-bottom: 1px solid var(--border);
+            padding: 1rem 0;
+            position: sticky;
+            top: 0;
+            z-index: 100;
+        }
+
+        nav {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+        }
+
+        .logo {
+            font-size: 1.5rem;
+            font-weight: 700;
+            color: var(--text);
+        }
+
+        .nav-links {
+            display: flex;
+            gap: 2rem;
+            list-style: none;
+        }
+
+        .nav-links a {
+            color: var(--text-muted);
+            font-weight: 500;
+        }
+
+        .nav-links a:hover {
+            color: var(--primary);
+            text-decoration: none;
+        }
+
+        /* Hero */
+        .hero {
+            padding: 5rem 0;
+            text-align: center;
+            background: linear-gradient(135deg, var(--bg-alt) 0%, var(--bg) 100%);
+        }
+
+        .hero h1 {
+            font-size: 3rem;
+            font-weight: 800;
+            margin-bottom: 1rem;
+            color: var(--text);
+        }
+
+        .hero .tagline {
+            font-size: 1.25rem;
+            color: var(--text-muted);
+            max-width: 700px;
+            margin: 0 auto 2rem;
+        }
+
+        .badge {
+            display: inline-block;
+            background: var(--secondary);
+            color: white;
+            padding: 0.25rem 0.75rem;
+            border-radius: 9999px;
+            font-size: 0.875rem;
+            font-weight: 600;
+            margin-bottom: 1rem;
+        }
+
+        .cta-buttons {
+            display: flex;
+            gap: 1rem;
+            justify-content: center;
+            flex-wrap: wrap;
+        }
+
+        .btn {
+            display: inline-flex;
+            align-items: center;
+            gap: 0.5rem;
+            padding: 0.875rem 1.75rem;
+            border-radius: 0.5rem;
+            font-weight: 600;
+            font-size: 1rem;
+            transition: all 0.2s;
+        }
+
+        .btn-primary {
+            background: var(--primary);
+            color: white;
+        }
+
+        .btn-primary:hover {
+            background: var(--primary-dark);
+            text-decoration: none;
+        }
+
+        .btn-secondary {
+            background: var(--bg);
+            color: var(--text);
+            border: 1px solid var(--border);
+        }
+
+        .btn-secondary:hover {
+            background: var(--bg-alt);
+            text-decoration: none;
+        }
+
+        /* Features */
+        .features {
+            padding: 5rem 0;
+        }
+
+        .section-title {
+            text-align: center;
+            font-size: 2rem;
+            font-weight: 700;
+            margin-bottom: 3rem;
+        }
+
+        .feature-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+            gap: 2rem;
+        }
+
+        .feature-card {
+            background: var(--bg);
+            border: 1px solid var(--border);
+            border-radius: 0.75rem;
+            padding: 1.5rem;
+            transition: box-shadow 0.2s;
+        }
+
+        .feature-card:hover {
+            box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+        }
+
+        .feature-icon {
+            font-size: 2rem;
+            margin-bottom: 1rem;
+        }
+
+        .feature-card h3 {
+            font-size: 1.25rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .feature-card p {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+        }
+
+        /* Why Section */
+        .why {
+            padding: 5rem 0;
+            background: var(--bg-alt);
+        }
+
+        .why-content {
+            max-width: 800px;
+            margin: 0 auto;
+            text-align: center;
+        }
+
+        .why-list {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+            gap: 1.5rem;
+            margin-top: 2rem;
+            text-align: left;
+        }
+
+        .why-item {
+            display: flex;
+            align-items: flex-start;
+            gap: 0.75rem;
+        }
+
+        .why-item span {
+            color: var(--secondary);
+            font-size: 1.25rem;
+        }
+
+        /* Code Example */
+        .code-section {
+            padding: 5rem 0;
+        }
+
+        .code-tabs {
+            display: flex;
+            gap: 0.5rem;
+            margin-bottom: 1rem;
+            flex-wrap: wrap;
+        }
+
+        .code-tab {
+            padding: 0.5rem 1rem;
+            background: var(--bg-alt);
+            border: 1px solid var(--border);
+            border-radius: 0.375rem;
+            cursor: pointer;
+            font-size: 0.875rem;
+            font-weight: 500;
+            transition: all 0.2s;
+        }
+
+        .code-tab:hover, .code-tab.active {
+            background: var(--primary);
+            color: white;
+            border-color: var(--primary);
+        }
+
+        .code-block {
+            background: var(--code-bg);
+            border-radius: 0.75rem;
+            padding: 1.5rem;
+            overflow-x: auto;
+        }
+
+        .code-block code {
+            color: var(--code-text);
+            font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', monospace;
+            font-size: 0.875rem;
+            line-height: 1.7;
+        }
+
+        .code-block .comment {
+            color: #6b7280;
+        }
+
+        .code-block .keyword {
+            color: #c084fc;
+        }
+
+        .code-block .string {
+            color: #86efac;
+        }
+
+        .code-block .function {
+            color: #60a5fa;
+        }
+
+        .code-content {
+            display: none;
+        }
+
+        .code-content.active {
+            display: block;
+        }
+
+        /* Hardware */
+        .hardware {
+            padding: 5rem 0;
+            background: var(--bg-alt);
+        }
+
+        .hardware-grid {
+            display: grid;
+            grid-template-columns: repeat(2, 1fr);
+            gap: 2rem;
+            max-width: 800px;
+            margin: 0 auto;
+        }
+
+        @media (max-width: 600px) {
+            .hardware-grid {
+                grid-template-columns: 1fr;
+            }
+        }
+
+        .hardware-card {
+            background: var(--bg);
+            border: 1px solid var(--border);
+            border-radius: 0.75rem;
+            padding: 1.5rem;
+        }
+
+        .hardware-card h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+        }
+
+        .hardware-card ul {
+            list-style: none;
+            color: var(--text-muted);
+        }
+
+        .hardware-card li {
+            padding: 0.25rem 0;
+        }
+
+        .hardware-card li::before {
+            content: "•";
+            color: var(--secondary);
+            margin-right: 0.5rem;
+        }
+
+        /* Install */
+        .install {
+            padding: 5rem 0;
+        }
+
+        .install-options {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+            gap: 2rem;
+            max-width: 900px;
+            margin: 0 auto;
+        }
+
+        .install-option {
+            background: var(--bg);
+            border: 1px solid var(--border);
+            border-radius: 0.75rem;
+            padding: 1.5rem;
+        }
+
+        .install-option h3 {
+            font-size: 1.125rem;
+            margin-bottom: 1rem;
+        }
+
+        .install-option ol {
+            color: var(--text-muted);
+            padding-left: 1.25rem;
+        }
+
+        .install-option li {
+            padding: 0.25rem 0;
+        }
+
+        .install-option code {
+            background: var(--code-bg);
+            color: var(--code-text);
+            padding: 0.625rem 1rem;
+            border-radius: 0.375rem;
+            display: block;
+            margin-top: 0.5rem;
+            font-size: 0.875rem;
+        }
+
+        /* Footer */
+        footer {
+            background: var(--code-bg);
+            color: var(--code-text);
+            padding: 3rem 0;
+            text-align: center;
+        }
+
+        footer a {
+            color: var(--code-text);
+        }
+
+        footer a:hover {
+            color: white;
+        }
+
+        .footer-links {
+            display: flex;
+            justify-content: center;
+            gap: 2rem;
+            margin-bottom: 1.5rem;
+            flex-wrap: wrap;
+        }
+
+        .footer-copy {
+            color: var(--text-muted);
+            font-size: 0.875rem;
+        }
+
+        /* Responsive */
+        @media (max-width: 768px) {
+            .hero h1 {
+                font-size: 2rem;
+            }
+
+            .hero .tagline {
+                font-size: 1rem;
+            }
+
+            .nav-links {
+                display: none;
+            }
+
+            .section-title {
+                font-size: 1.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <header>
+        <nav class="container">
+            <a href="#" class="logo">ArduRoomba</a>
+            <ul class="nav-links">
+                <li><a href="#features">Features</a></li>
+                <li><a href="#quickstart">Quick Start</a></li>
+                <li><a href="#hardware">Hardware</a></li>
+                <li><a href="#install">Install</a></li>
+                <li><a href="https://github.com/pkyanam/ArduRoomba">GitHub</a></li>
+            </ul>
+        </nav>
+    </header>
+
+    <section class="hero">
+        <div class="container">
+            <span class="badge">v3.1.0 - WiFi & Bluetooth</span>
+            <h1>Breathe New Life Into Your Roomba</h1>
+            <p class="tagline">
+                The definitive Arduino library for controlling legacy iRobot Roomba robots with WiFi and Bluetooth. Turn e-waste into smart robots.
+            </p>
+            <div class="cta-buttons">
+                <a href="https://github.com/pkyanam/ArduRoomba" class="btn btn-primary">
+                    View on GitHub
+                </a>
+                <a href="#quickstart" class="btn btn-secondary">
+                    Get Started
+                </a>
+            </div>
+        </div>
+    </section>
+
+    <section class="why">
+        <div class="container">
+            <div class="why-content">
+                <h2 class="section-title">Why ArduRoomba?</h2>
+                <p style="color: var(--text-muted); margin-bottom: 1rem;">
+                    Millions of perfectly functional Roomba robots sit in closets or landfills because their apps were discontinued or batteries died. The motors, sensors, and chassis are still good.
+                </p>
+                <div class="why-list">
+                    <div class="why-item">
+                        <span>&#10003;</span>
+                        <div><strong>Revive old hardware</strong> - Connect an Arduino or ESP32 and control via WiFi or Bluetooth</div>
+                    </div>
+                    <div class="why-item">
+                        <span>&#10003;</span>
+                        <div><strong>Build custom robots</strong> - Use the Roomba chassis as a base for your own projects</div>
+                    </div>
+                    <div class="why-item">
+                        <span>&#10003;</span>
+                        <div><strong>Learn robotics</strong> - Affordable platform with real sensors and actuators</div>
+                    </div>
+                    <div class="why-item">
+                        <span>&#10003;</span>
+                        <div><strong>Reduce e-waste</strong> - Give your old robot a second life instead of throwing it away</div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <section class="features" id="features">
+        <div class="container">
+            <h2 class="section-title">Features</h2>
+            <div class="feature-grid">
+                <div class="feature-card">
+                    <div class="feature-icon">&#128225;</div>
+                    <h3>Complete OI Protocol</h3>
+                    <p>Full iRobot Open Interface implementation - movement, sensors, LEDs, sounds, and more.</p>
+                </div>
+                <div class="feature-card">
+                    <div class="feature-icon">&#128246;</div>
+                    <h3>WiFi Control</h3>
+                    <p>Control your Roomba from any web browser. Supports Arduino Uno R4 WiFi and ESP32.</p>
+                </div>
+                <div class="feature-card">
+                    <div class="feature-icon">&#128225;</div>
+                    <h3>Bluetooth LE</h3>
+                    <p>ESP32 BLE support for mobile app control. Works with nRF Connect, LightBlue, or custom apps.</p>
+                </div>
+                <div class="feature-card">
+                    <div class="feature-icon">&#127760;</div>
+                    <h3>Web Interface</h3>
+                    <p>Responsive, mobile-friendly control panel with directional controls and live status.</p>
+                </div>
+                <div class="feature-card">
+                    <div class="feature-icon">&#128200;</div>
+                    <h3>Sensor Access</h3>
+                    <p>Read bumpers, cliff sensors, wall sensors, battery voltage, and button states.</p>
+                </div>
+                <div class="feature-card">
+                    <div class="feature-icon">&#128295;</div>
+                    <h3>Two-Layer Design</h3>
+                    <p>Simple high-level API for common tasks, plus direct protocol access for advanced users.</p>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <section class="code-section" id="quickstart">
+        <div class="container">
+            <h2 class="section-title">Quick Start</h2>
+            <div class="code-tabs">
+                <button class="code-tab active" onclick="showCode('basic')">Basic Control</button>
+                <button class="code-tab" onclick="showCode('wifi-uno')">WiFi (Uno R4)</button>
+                <button class="code-tab" onclick="showCode('wifi-esp32')">WiFi (ESP32)</button>
+                <button class="code-tab" onclick="showCode('ble')">Bluetooth (ESP32)</button>
+            </div>
+            <div class="code-block">
+                <div id="code-basic" class="code-content active">
+<code><span class="keyword">#include</span> <span class="string">"ArduRoomba.h"</span>
+
+ArduRoomba roomba(<span class="string">2</span>, <span class="string">3</span>, <span class="string">4</span>); <span class="comment">// RX, TX, BRC pins</span>
+
+<span class="keyword">void</span> <span class="function">setup</span>() {
+  Serial.<span class="function">begin</span>(<span class="string">19200</span>);
+  <span class="keyword">if</span> (roomba.<span class="function">begin</span>()) {
+    Serial.<span class="function">println</span>(<span class="string">"Roomba connected!"</span>);
+    roomba.<span class="function">moveForward</span>();
+    <span class="function">delay</span>(<span class="string">2000</span>);
+    roomba.<span class="function">stop</span>();
+  }
+}
+
+<span class="keyword">void</span> <span class="function">loop</span>() {}</code>
+                </div>
+                <div id="code-wifi-uno" class="code-content">
+<code><span class="keyword">#include</span> <span class="string">"ArduRoomba.h"</span>
+<span class="keyword">#include</span> <span class="string">"extensions/ArduRoombaWiFiS3.h"</span>
+
+ArduRoomba roomba(<span class="string">2</span>, <span class="string">3</span>, <span class="string">4</span>);
+ArduRoombaWiFiS3 wifi(roomba);
+
+<span class="keyword">void</span> <span class="function">setup</span>() {
+  Serial.<span class="function">begin</span>(<span class="string">19200</span>);
+  roomba.<span class="function">begin</span>();
+
+  <span class="comment">// Create WiFi access point</span>
+  wifi.<span class="function">beginAP</span>(<span class="string">"ArduRoomba"</span>, <span class="string">"roomba123"</span>);
+  wifi.<span class="function">startWebServer</span>();
+
+  Serial.<span class="function">print</span>(<span class="string">"Control at: http://"</span>);
+  Serial.<span class="function">println</span>(wifi.<span class="function">getIPAddress</span>());
+}
+
+<span class="keyword">void</span> <span class="function">loop</span>() {
+  wifi.<span class="function">handleClient</span>();
+}</code>
+                </div>
+                <div id="code-wifi-esp32" class="code-content">
+<code><span class="keyword">#include</span> <span class="string">"ArduRoomba.h"</span>
+<span class="keyword">#include</span> <span class="string">"extensions/ArduRoombaESP32WiFi.h"</span>
+
+ArduRoomba roomba(<span class="string">16</span>, <span class="string">17</span>, <span class="string">5</span>);
+ArduRoombaESP32WiFi wifi(roomba);
+
+<span class="keyword">void</span> <span class="function">setup</span>() {
+  Serial.<span class="function">begin</span>(<span class="string">115200</span>);
+  roomba.<span class="function">begin</span>();
+
+  <span class="comment">// Connect to existing WiFi network</span>
+  wifi.<span class="function">beginClient</span>(<span class="string">"YourSSID"</span>, <span class="string">"YourPassword"</span>);
+  wifi.<span class="function">startWebServer</span>();
+
+  Serial.<span class="function">print</span>(<span class="string">"Control at: http://"</span>);
+  Serial.<span class="function">println</span>(wifi.<span class="function">getIPAddress</span>());
+}
+
+<span class="keyword">void</span> <span class="function">loop</span>() {
+  wifi.<span class="function">handleClient</span>();
+}</code>
+                </div>
+                <div id="code-ble" class="code-content">
+<code><span class="keyword">#include</span> <span class="string">"ArduRoomba.h"</span>
+<span class="keyword">#include</span> <span class="string">"extensions/ArduRoombaBLE.h"</span>
+
+ArduRoomba roomba(<span class="string">16</span>, <span class="string">17</span>, <span class="string">5</span>);
+ArduRoombaBLE ble(roomba, <span class="string">"ArduRoomba"</span>);
+
+<span class="keyword">void</span> <span class="function">setup</span>() {
+  Serial.<span class="function">begin</span>(<span class="string">115200</span>);
+  roomba.<span class="function">begin</span>();
+  ble.<span class="function">begin</span>();
+  Serial.<span class="function">println</span>(<span class="string">"Connect via BLE app"</span>);
+}
+
+<span class="keyword">void</span> <span class="function">loop</span>() {
+  ble.<span class="function">updateStatus</span>();
+}</code>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <section class="hardware" id="hardware">
+        <div class="container">
+            <h2 class="section-title">Supported Hardware</h2>
+            <div class="hardware-grid">
+                <div class="hardware-card">
+                    <h3>&#128187; Microcontrollers</h3>
+                    <ul>
+                        <li>Arduino Uno R3</li>
+                        <li>Arduino Uno R4 WiFi</li>
+                        <li>Arduino Mega</li>
+                        <li>ESP32</li>
+                        <li>ESP8266</li>
+                    </ul>
+                </div>
+                <div class="hardware-card">
+                    <h3>&#129302; Roomba Models</h3>
+                    <ul>
+                        <li>iRobot Create 2</li>
+                        <li>Roomba 500 series</li>
+                        <li>Roomba 600 series</li>
+                        <li>Roomba 700 series</li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <section class="install" id="install">
+        <div class="container">
+            <h2 class="section-title">Installation</h2>
+            <div class="install-options">
+                <div class="install-option">
+                    <h3>Arduino Library Manager</h3>
+                    <ol>
+                        <li>Open Arduino IDE</li>
+                        <li>Go to Sketch &rarr; Include Library &rarr; Manage Libraries</li>
+                        <li>Search for "ArduRoomba"</li>
+                        <li>Click Install</li>
+                    </ol>
+                </div>
+                <div class="install-option">
+                    <h3>PlatformIO</h3>
+                    <p style="color: var(--text-muted); margin-bottom: 0.5rem;">Add to your platformio.ini:</p>
+                    <code>lib_deps = pkyanam/ArduRoomba</code>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <footer>
+        <div class="container">
+            <div class="footer-links">
+                <a href="https://github.com/pkyanam/ArduRoomba">GitHub</a>
+                <a href="https://github.com/pkyanam/ArduRoomba/releases">Releases</a>
+                <a href="https://github.com/pkyanam/ArduRoomba/issues">Issues</a>
+                <a href="https://deepwiki.com/pkyanam/ArduRoomba">DeepWiki</a>
+            </div>
+            <p class="footer-copy">
+                MIT License &bull; Free for commercial and non-commercial use
+            </p>
+        </div>
+    </footer>
+
+    <script>
+        function showCode(tab) {
+            // Remove active class from all tabs and content
+            document.querySelectorAll('.code-tab').forEach(t => t.classList.remove('active'));
+            document.querySelectorAll('.code-content').forEach(c => c.classList.remove('active'));
+
+            // Add active class to selected tab and content
+            event.target.classList.add('active');
+            document.getElementById('code-' + tab).classList.add('active');
+        }
+    </script>
+</body>
+</html>


### PR DESCRIPTION
Create a simple, responsive single-page website for ArduRoomba documentation hosted on GitHub Pages. Features include:

- Hero section with project tagline and CTAs
- Feature highlights (WiFi, Bluetooth, OI protocol, sensors)
- Interactive code examples with tabs for different platforms
- Hardware compatibility information
- Installation instructions
- Modern, clean design with no external dependencies

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a responsive, single-page docs site in `docs/index.html` with features, quickstart code tabs, hardware, installation, and footer.
> 
> - **Docs/Website**:
>   - Add static site at `docs/index.html`.
>     - Hero with CTA, sticky nav, emoji favicon.
>     - Features and "Why" sections.
>     - Quick Start with tabbed code samples using `showCode` JS.
>     - Supported hardware and Installation sections.
>     - Themed CSS with responsive layout; no external dependencies.
>     - Footer with project links and license note.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8fd6ff2687072871b87448fdaf61892aff8d877c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->